### PR TITLE
chore(fix): Allow GitHub action to write security events

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   packages: write
+  security-events: write
 
 jobs:
   publish-docker-image:


### PR DESCRIPTION
Apparently this permission is required to allow the GitHub action to write security events, even though it already did so in #2.
