### PR TITLE
chore: Specify runtime environment

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -40,9 +40,6 @@ COPY ./server/static ./dist/static
 # Build server and include frontend (docroot is set to ../client in config.json)
 FROM node:lts-alpine
 
-ARG ENVIRONMENT=production
-ENV NODE_ENV=${ENVIRONMENT}
-
 COPY --from=be-builder /app/dist/. /server
 COPY --from=fe-builder /app/dist/. /client
 
@@ -54,6 +51,7 @@ RUN mkdir sessions
 RUN chmod -R 777 sessions
 USER irma
 
+ENV NODE_ENV=production
 ENV DEBUG=express-session
 
 CMD ["pm2-runtime","./app.js"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -2,7 +2,6 @@
 FROM node:14.4-alpine AS fe-builder
 LABEL maintainer="support@yivi.app"
 
-ENV NODE_ENV=${ENVIRONMENT}
 ENV PATH=/app/node_modules/.bin:$PATH
 
 WORKDIR /app
@@ -17,7 +16,6 @@ RUN yarn build
 FROM node:lts-alpine AS be-builder
 LABEL maintainer="support@yivi.app"
 
-ENV NODE_ENV=${ENVIRONMENT}
 ENV PATH=/app/node_modules/.bin:$PATH
 
 WORKDIR /app
@@ -41,6 +39,9 @@ COPY ./server/static ./dist/static
 
 # Build server and include frontend (docroot is set to ../client in config.json)
 FROM node:lts-alpine
+
+ARG ENVIRONMENT=production
+ENV NODE_ENV=${ENVIRONMENT}
 
 COPY --from=be-builder /app/dist/. /server
 COPY --from=fe-builder /app/dist/. /client


### PR DESCRIPTION
The NODE_ENV isn't set because the ENVIRONMENT argument as specified in the original Dockerfile.prod was not available. If the variable is not set to `production` or `acceptance` it will result in a non-recoverable error on startup.