### PR TITLE
chore: resolve non-breaking client security advisories

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2368,6 +2368,29 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -14444,25 +14467,27 @@
             "license": "ISC"
         },
         "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">= 18"
             }
         },
-        "node_modules/minizlib/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
         },
         "node_modules/mississippi": {
             "version": "3.0.0",
@@ -17914,13 +17939,13 @@
             "license": "MIT"
         },
         "node_modules/serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-index": {
@@ -19610,53 +19635,51 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "version": "7.5.16",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
+            }
+        },
+        "node_modules/tar/node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tar/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/tar/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
             "dev": true,
-            "license": "ISC"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/terminal-link": {
             "version": "2.1.1",
@@ -19903,16 +19926,6 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/ssri": {

--- a/client/package.json
+++ b/client/package.json
@@ -104,6 +104,8 @@
         "write-file-webpack-plugin": "^4.5.1"
     },
     "overrides": {
-        "trim": "^1.0.1"
+        "trim": "^1.0.1",
+        "serialize-javascript": "^7.0.5",
+        "tar": "^7.5.16"
     }
 }


### PR DESCRIPTION
## Summary

Clears the client security advisories that have fixes **not** requiring a major build-chain migration, by pinning two vulnerable transitive packages via `overrides`:

- **`serialize-javascript` ^7.0.5** — HIGH: RCE/XSS in terser-webpack-plugin / copy-webpack-plugin output serialization
- **`tar` ^7.5.16** — HIGH: path traversal / arbitrary file write in build caching (via `cacache`)

## Impact

- Client advisories: **65 → 60** (HIGH: **17 → 12**) — all 5 cleared are HIGH severity
- `npm run build` passes
- Dependency tree gains **no** new invalid peers (stays at the legacy baseline)
- No production runtime code changed — both packages are build-time only

`npm audit fix` is a no-op here: every remaining fixable leaf is pinned by a parent (jest 26 / css-loader 4 / webpack 4), so npm can't upgrade in place without `--force` (which pulls webpack 5 / wds 5). `overrides` is the only lever that works without the major migration.

## Out of scope

The remaining 60 advisories are all **dev-only build tooling** (webpack 4, webpack-dev-server 3, jest 26, stylelint 13) that don't ship in the production bundle. Clearing them requires a major build-chain migration (webpack 5 / jest 30 / stylelint 17), kept out of this PR to keep the app building and tests green.

One remaining advisory does ship (`@amsterdam/arm-core` → `uuid`, moderate) but is non-exploitable here (the advisory needs a `buf` argument; arm-core calls `uuid()` with none) and can't be overridden without breaking arm-core's use of the removed uuid v3 default-export API — it needs an arm-core upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)