### PR TITLE
chore: fix form-data CRLF injection and patch pm2 bundled ws/js-yaml

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -44,7 +44,8 @@ FROM node:24-alpine
 COPY --from=be-builder /app/dist/. /server
 COPY --from=fe-builder /app/dist/. /client
 
-RUN apk update && apk upgrade && npm install pm2 -g
+RUN apk update && apk upgrade && npm install pm2 -g && \
+    npm install --prefix /usr/local/lib/node_modules/pm2 ws@8.21.0 js-yaml@4.2.0
 WORKDIR /server
 
 RUN adduser -D irma

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7052,22 +7052,6 @@
                 "axios": ">= 0.17.0"
             }
         },
-        "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/axobject-query": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -10931,6 +10915,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {

--- a/client/package.json
+++ b/client/package.json
@@ -108,6 +108,7 @@
         "@tootallnate/once": "^2.0.1",
         "node-forge": "^1.4.0",
         "postcss": "^8.5.10",
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^4.2.0",
+        "form-data": "^4.0.6"
     }
 }


### PR DESCRIPTION
## Summary

- Override `form-data` to `^4.0.6` in `client/package.json` to close Dependabot alert [#265](https://github.com/privacybydesign/amsterdam-demo/security/dependabot/265) (CRLF injection via `axios` → `form-data@4.0.5`)
- After `npm install pm2 -g` in `Dockerfile.prod`, force-upgrade pm2's bundled `ws` to `8.21.0` and `js-yaml` to `4.2.0` to close image-scan alerts [#225](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/225) (GHSA-96hv-2xvq-fx4p, ws memory exhaustion DoS) and [#226](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/226) (GHSA-h67p-54hq-rp68, js-yaml quadratic DoS). pm2@7.0.1 bundles `ws@8.20.0` (unfixed) and `js-yaml@4.1.1` (unfixed); the patch installs the fixed versions into pm2's own `node_modules` directory at image build time.

Alerts #222, #223, #224, and #227 (brace-expansion, ip-address, old ws DoS, and tar in npm's bundled modules) are addressed by the node:24 upgrade in PR #40 and are not changed here.