### PR TITLE
chore: fix 6 remaining image-scan security alerts

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -44,8 +44,11 @@ FROM node:24-alpine
 COPY --from=be-builder /app/dist/. /server
 COPY --from=fe-builder /app/dist/. /client
 
-RUN apk update && apk upgrade && npm install pm2 -g && \
-    npm install --prefix /usr/local/lib/node_modules/pm2 ws@8.21.0 js-yaml@4.2.0
+RUN apk update && apk upgrade && \
+    npm install -g npm@latest && \
+    npm install -g pm2 && \
+    npm install --prefix /usr/local/lib/node_modules/pm2 \
+        ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2
 WORKDIR /server
 
 RUN adduser -D irma


### PR DESCRIPTION
## Summary

All 6 currently open code-scanning alerts are in the production Docker image, split between npm's own bundled modules and pm2's bundled modules.

**npm-bundled fixes** (via `npm install -g npm@latest` → npm 11.x):
- [#222](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/222) `brace-expansion` GHSA-jxxr-4gwj-5jf2 — fixed in brace-expansion 5.0.6, bundled by npm 11.x
- [#223](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/223) `ip-address` GHSA-v2v4-37r5-5v8g — fixed in ip-address 10.1.1, bundled by npm 11.x
- [#227](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/227) `tar` GHSA-vmf3-w455-68vh — fixed in tar 7.5.16; npm 11.17.0 directly pins `tar@^7.5.16`

**pm2-bundled fixes** (via `npm install --prefix /usr/local/lib/node_modules/pm2`):
- [#228](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/228) `serialize-javascript` GHSA-qj8w-gfj5-8c6v (medium) — patched to 7.0.6
- [#229](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/229) `diff` GHSA-73rr-hh4g-fpgx (low) — patched to 5.2.2
- [#230](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/230) `serialize-javascript` GHSA-5c6j-r48x-rmvq (high) — patched to 7.0.6