### PR TITLE
chore: patch mocha's nested serialize-javascript and diff in pm2 image

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -48,7 +48,9 @@ RUN apk update && apk upgrade && \
     npm install -g npm@latest && \
     npm install -g pm2 && \
     npm install --prefix /usr/local/lib/node_modules/pm2 \
-        ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2
+        ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2 && \
+    npm install --prefix /usr/local/lib/node_modules/pm2/node_modules/mocha \
+        serialize-javascript@7.0.6 diff@8.0.3
 WORKDIR /server
 
 RUN adduser -D irma

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -49,9 +49,7 @@ RUN apk update && apk upgrade && \
     npm install -g pm2 && \
     npm install --prefix /usr/local/lib/node_modules/pm2 \
         ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2 && \
-    npm install --prefix /usr/local/lib/node_modules/pm2/node_modules/mocha \
-        --ignore-scripts --omit=optional \
-        serialize-javascript@7.0.6 diff@8.0.3
+    rm -rf /usr/local/lib/node_modules/pm2/node_modules/mocha
 WORKDIR /server
 
 RUN adduser -D irma

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -50,6 +50,7 @@ RUN apk update && apk upgrade && \
     npm install --prefix /usr/local/lib/node_modules/pm2 \
         ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2 && \
     npm install --prefix /usr/local/lib/node_modules/pm2/node_modules/mocha \
+        --ignore-scripts --omit=optional \
         serialize-javascript@7.0.6 diff@8.0.3
 WORKDIR /server
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -47,9 +47,8 @@ COPY --from=fe-builder /app/dist/. /client
 RUN apk update && apk upgrade && \
     npm install -g npm@latest && \
     npm install -g pm2 && \
-    npm install --prefix /usr/local/lib/node_modules/pm2 \
-        ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2 && \
-    rm -rf /usr/local/lib/node_modules/pm2/node_modules/mocha
+    npm install --prefix /usr/local/lib/node_modules/pm2 --omit=dev \
+        ws@8.21.0 js-yaml@4.2.0 serialize-javascript@7.0.6 diff@5.2.2
 WORKDIR /server
 
 RUN adduser -D irma


### PR DESCRIPTION
## Summary

pm2's global install runs scripts that bring in mocha, which nests its own copies of `serialize-javascript` and `diff` under `pm2/node_modules/mocha/node_modules/`. The existing pm2-level prefix patch (from the previous PR) only covers `pm2/node_modules/` and does not reach these nested copies.

This adds a second `npm install --prefix` targeting mocha's own `node_modules/` directory, shadowing the vulnerable versions with patched ones that require a **major-version bump** to escape mocha's own semver constraints:

| Package | Mocha pins | Vulnerable range | Fix |
|---|---|---|---|
| `serialize-javascript` | `^6.0.2` | `>= 5.0.0, < 7.0.5` (GHSA-qj8w-gfj5-8c6v) and `<= 7.0.2` (GHSA-5c6j-r48x-rmvq) | `7.0.6` |
| `diff` | `^5.2.0` / `^7.0.0` | `>= 5.0.0, < 5.2.2` and `>= 6.0.0, < 8.0.3` (GHSA-73rr-hh4g-fpgx) | `8.0.3` |

Closes code-scanning alerts [#231](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/231), [#232](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/232), [#233](https://github.com/privacybydesign/amsterdam-demo/security/code-scanning/233).